### PR TITLE
Update Ubuntu 2022-08-29

### DIFF
--- a/library/ubuntu
+++ b/library/ubuntu
@@ -1,48 +1,48 @@
 # see https://partner-images.canonical.com/core/
 # see also https://wiki.ubuntu.com/Releases#Current
 
-Maintainers: Tianon Gravi <tianon@debian.org> (@tianon), Michael Hudson-Doyle <michael.hudson@ubuntu.com> (@mwhudson)
-GitRepo: https://github.com/tianon/docker-brew-ubuntu-core.git
-GitCommit: 669a7da67dd3f2a0fe3131df2134ce1682b4d589
-# https://github.com/tianon/docker-brew-ubuntu-core/tree/dist-amd64
+Maintainers: Tomáš Virtus <tomas.virtus@canonical.com> (@woky), Michael Hudson-Doyle <michael.hudson@ubuntu.com> (@mwhudson)
+GitRepo: https://git.launchpad.net/virtustom-cloud-images2/+oci/ubuntu-base
+GitCommit: 787d3b958e7c30b02a97b65c3166bf5257af64dc
+# https://git.launchpad.net/virtustom-cloud-images2/+oci/ubuntu-base/tree/?h=dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: 570d5970a8b18bc772ad2c3eb1ce8fd0887d991a
-# https://github.com/tianon/docker-brew-ubuntu-core/tree/dist-arm32v7
+amd64-GitCommit: 9edd33864d1baecfebf5aa5f557389eb636695a9
+# https://git.launchpad.net/virtustom-cloud-images2/+oci/ubuntu-base/tree/?h=dist-arm32v7
 arm32v7-GitFetch: refs/heads/dist-arm32v7
-arm32v7-GitCommit: ac66de83cc2f2312bc73edc549ea472542904126
-# https://github.com/tianon/docker-brew-ubuntu-core/tree/dist-arm64v8
+arm32v7-GitCommit: 3b026ab7d888df59a337ffb7c2f632e0d88d11bd
+# https://git.launchpad.net/virtustom-cloud-images2/+oci/ubuntu-base/tree/?h=dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: ccdcd5d4a1f938cda92e7cb3999fca58188c333f
-# https://github.com/tianon/docker-brew-ubuntu-core/tree/dist-i386
+arm64v8-GitCommit: 08c5ba01fe2ddc8f51ed3da0adc1394ec6961bea
+# https://git.launchpad.net/virtustom-cloud-images2/+oci/ubuntu-base/tree/?h=dist-i386
 i386-GitFetch: refs/heads/dist-i386
-i386-GitCommit: f5d9eb38715af54eb96bc68f0b3a240d676400f9
-# https://github.com/tianon/docker-brew-ubuntu-core/tree/dist-ppc64le
+i386-GitCommit: d7c0c9733e15184152f8a1b076e1e12ad600e733
+# https://git.launchpad.net/virtustom-cloud-images2/+oci/ubuntu-base/tree/?h=dist-ppc64le
 ppc64le-GitFetch: refs/heads/dist-ppc64le
-ppc64le-GitCommit: 06e3fd240a6c2783695356ba4773f1688143c600
-# https://github.com/tianon/docker-brew-ubuntu-core/tree/dist-riscv64
+ppc64le-GitCommit: 67f059ebca54685755f61a4488c582e255eadd82
+# https://git.launchpad.net/virtustom-cloud-images2/+oci/ubuntu-base/tree/?h=dist-riscv64
 riscv64-GitFetch: refs/heads/dist-riscv64
-riscv64-GitCommit: a7dffe6da7341dbc01c1c373b99493aa2f4f3fb5
-# https://github.com/tianon/docker-brew-ubuntu-core/tree/dist-s390x
+riscv64-GitCommit: 3db012e9ecc9c8bc5c1f02022e9e532bf7170717
+# https://git.launchpad.net/virtustom-cloud-images2/+oci/ubuntu-base/tree/?h=dist-s390x
 s390x-GitFetch: refs/heads/dist-s390x
-s390x-GitCommit: ff6467ff309d1e8c1834f45dc088ab9bf71d019b
+s390x-GitCommit: 8f8cbbb972b3fdb3e58efb404521c6e827202107
 
-# 20220801 (bionic)
-Tags: 18.04, bionic-20220801, bionic
+# 20220815 (bionic)
+Tags: 18.04, bionic-20220815, bionic
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
 Directory: bionic
 
-# 20220801 (focal)
-Tags: 20.04, focal-20220801, focal
+# 20220101 (focal)
+Tags: 20.04, focal-20220101, focal
 Architectures: amd64, arm32v7, arm64v8, ppc64le, riscv64, s390x
 Directory: focal
 
-# 20220801 (jammy)
-Tags: 22.04, jammy-20220801, jammy, latest, rolling
+# 20220815 (jammy)
+Tags: 22.04, jammy-20220815, jammy, latest, rolling
 Architectures: amd64, arm32v7, arm64v8, ppc64le, riscv64, s390x
 Directory: jammy
 
-# 20220801 (kinetic)
-Tags: 22.10, kinetic-20220801, kinetic, devel
+# 20220815 (kinetic)
+Tags: 22.10, kinetic-20220815, kinetic, devel
 Architectures: amd64, arm32v7, arm64v8, ppc64le, riscv64, s390x
 Directory: kinetic
 


### PR DESCRIPTION
Update Ubuntu to latest published rootfs tarballs as of 2022-08-29.